### PR TITLE
add: use of logger instead of print for the pipeline logs

### DIFF
--- a/desafio-1/etl/clean_validate.py
+++ b/desafio-1/etl/clean_validate.py
@@ -1,4 +1,7 @@
+import logging
 import pandas as pd
+
+logger = logging.getLogger(__name__)
 
 def clean_and_validate(df: pd.DataFrame) -> pd.DataFrame:
     """
@@ -7,7 +10,7 @@ def clean_and_validate(df: pd.DataFrame) -> pd.DataFrame:
     - Valida e converte os tipos de dados
     - Remove linhas com dados inválidos ou ausentes
     """
-    print("Iniciando limpeza e validação dos dados...")
+    logger.info("Iniciando limpeza e validação dos dados...")
 
     # Limpeza nos campos de texto do CSV
     colunas_texto = ["origem", "destino", "status_rastreamento"]
@@ -27,9 +30,15 @@ def clean_and_validate(df: pd.DataFrame) -> pd.DataFrame:
     linhas_invalidas = df[df.isnull().any(axis=1)] # Cópia das linhas inválidas para análise
 
     if not linhas_invalidas.empty:
-        print(f"AVISO: Foram encontradas {len(linhas_invalidas)} linhas com dados inválidos/ausentes. Elas serão removidas")
-        print("Linhas removidas:")
-        print(linhas_invalidas)
+        indices_invalidos = linhas_invalidas.index.tolist()
+        logger.warning(
+            f"Foram encontradas {len(linhas_invalidas)} linhas com dados inválidos/ausentes. Elas serão removidas"
+            f"Índices removidos: {indices_invalidos}"
+        )
+
+        # Em nível de DEBUG é possível ver quais linhas são inválidas
+        invalid_rows_json = linhas_invalidas.to_json(orient='records', date_format='iso')
+        logger.debug(f"Conteúdo detalhado das linhas inválidas: {invalid_rows_json}")
 
     # Remove as linhas que tenham qualquer valor nulo (NaN ou NaT)
     df.dropna(inplace=True)
@@ -37,6 +46,6 @@ def clean_and_validate(df: pd.DataFrame) -> pd.DataFrame:
     # Com os NaN removidos, volta o tipo da coluna para int
     df["id_pacote"] = df["id_pacote"].astype(int)
 
-    print(f"Limpeza concluída. {len(df)}/{linhas_originais} linhas válidas restantes.")
+    logger.info(f"Limpeza concluída. {len(df)}/{linhas_originais} linhas válidas restantes.")
 
     return df

--- a/desafio-1/etl/extract.py
+++ b/desafio-1/etl/extract.py
@@ -1,4 +1,7 @@
+import logging
 import pandas as pd
+
+logger = logging.getLogger(__name__)
 
 def extract_from_csv(file_path: str) -> pd.DataFrame | None:
     """
@@ -7,20 +10,20 @@ def extract_from_csv(file_path: str) -> pd.DataFrame | None:
     """
 
     try:
-        print(f"Iniciando a extração do arquivo: {file_path}")
+        logger.info(f"Iniciando a extração do arquivo: {file_path}")
         df = pd.read_csv(file_path)
 
         if df.empty:
-            print(f"AVISO: O arquivo '{file_path}' está vazio.")
+            logger.warning(f"O arquivo '{file_path}' está vazio.")
             return None
         
-        print(f"Extração concluída com sucesso. {len(df)} linhas encontradas.")
+        logger.info(f"Extração concluída com sucesso. {len(df)} linhas encontradas.")
         return df
     
     except FileNotFoundError:
-        print(f"ERRO: O arquivo não foi encontrado no caminho: {file_path}")
+        logger.error(f"O arquivo não foi encontrado no caminho: {file_path}")
         return None
     except Exception as e:
-        print(f"ERRO: Ocorreu um erro inesperado ao ler o arquivo: {e}")
+        logger.exception(f"Ocorreu um erro inesperado ao ler o arquivo: {e}")
         return None
     

--- a/desafio-1/etl/transform.py
+++ b/desafio-1/etl/transform.py
@@ -1,5 +1,8 @@
+import logging
 import pandas as pd
 from typing import Tuple
+
+logger = logging.getLogger(__name__)
 
 def transform(df: pd.DataFrame) -> Tuple[pd.DataFrame, pd.DataFrame]:
     """ 
@@ -7,12 +10,21 @@ def transform(df: pd.DataFrame) -> Tuple[pd.DataFrame, pd.DataFrame]:
     tabelas `pacotes` e `eventos_rastreamento`    
     """
 
+    logger.info("Iniciando a etapa de transformação dos dados...")
+
+    numero_eventos = len(df)
+    logger.debug(f"DataFrame recebido com {numero_eventos} registrados.")
+
     # Cria o DataFrame dos eventos de rastreamento
     df_eventos = df[["id_pacote", "status_rastreamento", "data_atualizacao"]].copy()
     df_eventos.rename(columns={"data_atualizacao": "data_evento"}, inplace=True)
+    logger.debug(f"DataFrame de eventos criado com {len(df_eventos)} linhas.")
 
     # Garante que caso haja produtos duplicados no CSV, somente a primeira encontrada é considerada 
     df_pacotes = df[["id_pacote", "origem", "destino"]].copy()
     df_pacotes = df_pacotes.drop_duplicates(subset=["id_pacote"], keep='first')
+
+    logger.info(f"Identificados {len(df_pacotes)} únicos a partir de {numero_eventos} eventos.")
+    logger.info("Transformação concluída. DataFrames para pacotes e eventos estão prontos.")
 
     return df_pacotes, df_eventos

--- a/desafio-1/test_pipeline.py
+++ b/desafio-1/test_pipeline.py
@@ -1,9 +1,23 @@
+import logging
 from etl.extract import extract_from_csv
 from etl.clean_validate import clean_and_validate
 from etl.transform import transform
 from etl.load import load_data
 
+def setup_logging():
+    """
+    Configuração do sistema de logging do pipeline.
+    """
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(levelname)s] [%(name)s] - %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S"
+    )
+
 def run_pipeline():
+    logging.info("--- Início da Execução do Pipeline ETL ---")
+
     df_raw = extract_from_csv("rastreamento.csv")
 
     if df_raw is not None:
@@ -14,5 +28,8 @@ def run_pipeline():
 
             load_data(df_pacotes=df_pacotes, df_eventos=df_eventos)
 
+    logging.info("--- Fim da Execução do Pipeline ETL ---")
+
 if __name__ == "__main__":
+    setup_logging()
     run_pipeline()


### PR DESCRIPTION
## Processo de Pensamento

O objetivo principal era mover o projeto de um script com simples "prints" para uma aplicação que pode ser monitorada e depurada com logs bem definidos.

1.**Centralização da Configuração**: Em vez de configurar o logging em cada módulo, foi criada uma única função `setup_logging()` no script principal. Isso garante um formato de log consistente (timestamp, nível, nome do módulo, mensagem) em toda a aplicação e facilita futuras alterações.
2. **Contexto nas Mensagens**: Em cada módulo (extract, clean_validate, transform, load), foi utilizado `logging.getLogger(__name__)`. Esta prática "carimba" cada mensagem de log com o nome do arquivo de origem, permitindo identificar imediatamente de onde uma mensagem veio, o que é crucial para a depuração.
3. **Hierarquia da Informação**: Foi feito um uso deliberado dos níveis de log. Mensagens de progresso normais usam `logger.info()`, alertas sobre dados de má qualidade (que são tratados) usam `logger.warning()`, e erros que param a execução usam `logger.error()` ou `logger.exception()`. Isso permite filtrar a verbosidade dos logs em um ambiente de produção.