### PR TITLE
add: docker compose with timescaledb + new sql script implementing hy…

### DIFF
--- a/desafio-2/dashboard-realtime/docker-compose.yaml
+++ b/desafio-2/dashboard-realtime/docker-compose.yaml
@@ -1,0 +1,22 @@
+services:
+  timescaledb:
+    image: timescale/timescaledb:latest-pg17
+    container_name: timescaledb_logistica
+    environment:
+      - POSTGRES_USER=${POSTGRES_USER}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      - POSTGRES_DB=${POSTGRES_DB}
+    ports:
+      - "5434:5432"
+    volumes:
+      - timescaledb_data:/var/lib/postgresql/data
+      - ./init-db:/docker-entrypoint-initdb.d
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  timescaledb_data:

--- a/desafio-2/dashboard-realtime/init-db/create_tables.sql
+++ b/desafio-2/dashboard-realtime/init-db/create_tables.sql
@@ -1,0 +1,29 @@
+-- Habilita a extensão do TimescaleDB no banco de dados.
+CREATE EXTENSION IF NOT EXISTS timescaledb;
+
+CREATE TABLE pacotes (
+    id_pacote INT PRIMARY KEY,
+    origem TEXT NOT NULL,
+    destino TEXT NOT NULL,
+    data_criacao TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE eventos_rastreamento (
+    id_pacote INT NOT NULL,
+    status_rastreamento TEXT NOT NULL,
+    data_evento TIMESTAMP WITH TIME ZONE NOT NULL,
+
+    CONSTRAINT pk_eventos_rastreamento
+        PRIMARY KEY (id_pacote, data_evento),
+
+    CONSTRAINT fk_eventos_pacotes
+        FOREIGN KEY(id_pacote)
+        REFERENCES pacotes(id_pacote)
+);
+
+-- Converte a tabela de eventos_rastreamento em uma Hypertable.
+-- Particiona a tabela 'eventos_rastreamento' com base na coluna 'data_evento'.
+SELECT create_hypertable('eventos_rastreamento', 'data_evento');
+
+-- Índice para otimização de joins com a tabela pacotes.
+CREATE INDEX idx_eventos_id_pacote ON eventos_rastreamento(id_pacote);


### PR DESCRIPTION
## Processo de Pensamento

A implementação foi focada em adaptar a infraestrutura e o schema do banco de dados para serem compatíveis e otimizados para o TimescaleDB.

1. **Infraestrutura (Docker Compose)**: O arquivo `docker-compose.yaml` foi criado para utilizar a imagem oficial timescale/timescaledb:latest-pg16. Isso garante que a extensão TimescaleDB esteja disponível e pronta para uso na inicialização do contêiner.
2. **Habilitação da Extensão**: O script `create_tables.sql` foi modificado para incluir `CREATE EXTENSION IF NOT EXISTS timescaledb;` como o primeiro passo, ativando as funcionalidades de série temporal no banco de dados.
3. **Adaptação do Schema (Chave Primária)**: O ponto mais crítico foi a redefinição do schema da tabela `eventos_rastreamento` para atender aos requisitos do TimescaleDB. O comando `create_hypertable` exige que a coluna de particionamento (no nosso caso, `data_evento`) faça parte de todas as chaves primárias ou constraints de unicidade. 
Por isso:
      * A coluna `id_evento SERIAL PRIMARY KEY` foi removida;
      * Uma chave primária composta `PRIMARY KEY (id_pacote, data_evento)` foi criada. Esta é uma chave mais natural para os dados, pois a unicidade de um evento é inerentemente definida pelo pacote e pelo momento em que o evento ocorreu.
      * A `CONSTRAINT UNIQUE` anterior se tornou redundante e foi removida.