### PR TITLE
add: kafka and zookeeper containers on docker-compose to manage realt…

### DIFF
--- a/desafio-2/dashboard-realtime/docker-compose.yaml
+++ b/desafio-2/dashboard-realtime/docker-compose.yaml
@@ -18,5 +18,53 @@ services:
       timeout: 5s
       retries: 5
 
+  zookeeper:
+    image: confluentinc/cp-zookeeper:7.9.4
+    container_name: zookeeper_logistica
+    ports:
+      - "2181:2181"
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+    volumes:
+      - zookeeper_data:/var/lib/zookeeper/data
+      - zookeeper_log:/var/lib/zookeeper/log
+
+  kafka:
+    image: confluentinc/cp-kafka:7.9.4
+    container_name: kafka_logistica
+    ports:
+      - "9092:9092" # Listener interno
+      - "9094:9094" # Listener externo
+    depends_on:
+      - zookeeper
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: 'zookeeper:2181'
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,EXTERNAL:PLAINTEXT
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092,EXTERNAL://localhost:9094
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+    volumes:
+      - kafka_data:/var/lib/kafka/data
+
+  kafka-init:
+    image: confluentinc/cp-kafka:7.9.4
+    container_name: kafka_init_logistica
+    depends_on:
+      - kafka
+    command: >
+      bash -c "
+        echo 'Esperando o Kafka iniciar...' &&
+        cub kafka-ready -b kafka:9092 1 20 &&
+        echo 'Kafka iniciado. Criando tópico...' &&
+        kafka-topics --bootstrap-server kafka:9092 --create --if-not-exists --topic eventos_rastreamento --partitions 1 --replication-factor 1 &&
+        echo 'Tópico criado com sucesso.'
+      "
+
 volumes:
   timescaledb_data:
+  zookeeper_data:
+  zookeeper_log:
+  kafka_data:
+  


### PR DESCRIPTION
## Processo de Pensamento

A implementação foi focada em criar um ambiente Kafka funcional, de fácil gerenciamento e pronto para o desenvolvimento das próximas etapas (producer e consumer).

1. **Escolha das Imagens (Confluent)**:  A decisão foi por utilizar as imagens da Confluent Community Edition (`confluentinc/cp-kafka` e `confluentinc/cp-zookeeper`). Esta escolha se deu por serem mantidas pelos criadores originais do Kafka, serem gratuitas, bem documentadas e oferecerem uma configuração robusta via variáveis de ambiente, ideal para o Docker Compose.
2. **Configuração de Rede Híbrida**: A configuração do Kafka foi projetada para suportar tanto a comunicação interna (entre contêineres) quanto externa. Foram definidos dois `advertised.listeners`:
      * `PLAINTEXT://kafka:9092`: Para a comunicação dentro da rede Docker (o futuro serviço #31 se conectará a este endereço).
      * `EXTERNAL://localhost:9094`: Para a comunicação a partir da máquina host (para testes e para o futuro serviço #30).
3. **Criação Automatizada e Idempotente do Tópico**: Para remover a necessidade de passos manuais, foi criado um serviço `kafka-init`. Este contêiner temporário executa um script que:
      1. Espera o broker Kafka ficar totalmente pronto.
      2. Executa o comando `kafka-topics --create` para criar o tópico `eventos_rastreamento`.
      3. Utiliza a flag `--if-not-exists` para garantir que o script seja idempotente, podendo ser executado várias vezes sem causar erros.