### PR TITLE
add: producer script to emulate an API endpoint

### DIFF
--- a/desafio-2/dashboard-realtime/producer.py
+++ b/desafio-2/dashboard-realtime/producer.py
@@ -1,0 +1,100 @@
+import json
+import logging
+import time
+from kafka import KafkaProducer
+
+logger = logging.getLogger(__name__)
+
+def setup_logging():
+    """
+    Configuração do sistema de logging do pipeline.
+    """
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(levelname)s] [%(name)s] - %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+
+KAFKA_BROKER_URL = "localhost:9094"
+TOPIC_NAME = "eventos_rastreamento"
+
+def inicializar_producer() -> KafkaProducer | None:
+    """
+    Tenta criar e retornar uma instância do KafkaProducer.
+    Retorna None em caso de falha.
+    """
+
+    try:
+        producer = KafkaProducer(
+            bootstrap_servers=KAFKA_BROKER_URL,
+            value_serializer=lambda v: json.dumps(v).encode("utf-8"),
+            acks="all",
+            retries=5
+        )
+        logger.info("Kafka Producer conectado com sucesso")
+        return producer
+    except Exception as e:
+        logger.exception(f"Falha ao se conectar ao Kafka Producer: {e}")
+        return None
+    
+def enviar_evento(producer: KafkaProducer, evento: dict):
+    """
+    Envia um único evento de rastreamento para o tópico Kafka,
+    simulando o comportamento da API.
+
+    Args:
+        `producer`: A instância do KafkaProducer.
+        `evento`: Um dicionário Python representando o evento JSON.
+    """
+
+    try:
+        future = producer.send(TOPIC_NAME, value=evento)
+        result = future.get(timeout=10) # Espera 10 segundos
+        logger.info(f"Evento enviado com sucesso para o tópico '{result.topic}' na partição {result.partition}.")
+    except Exception as e:
+        logger.exception(f"Falha ao enviar evento para o Kafka: {e}")
+
+if __name__ == "__main__":
+    setup_logging()
+    logger.info("Iniciando script do produtor de eventos...")
+
+    kafka_producer = inicializar_producer()
+
+    if kafka_producer:
+        # Simulando requisições no endpoint da API
+
+        evento_1 = {
+            "id_pacote": 1420,
+            "origem": "Porto Alegre",
+            "destino": "Curitiba",
+            "status_rastreamento": "EM TRÂNSITO",
+            "data_atualizacao": "2025-10-11T10:15:00Z"
+        }
+        enviar_evento(kafka_producer, evento_1)
+
+        time.sleep(5)
+
+        evento_2 = {
+            "id_pacote": 1420,
+            "origem": "Porto Alegre",
+            "destino": "Curitiba",
+            "status_rastreamento": "EM ROTA DE ENTREGA",
+            "data_atualizacao": "2025-10-12T14:30:00Z"
+        }
+        enviar_evento(kafka_producer, evento_2)
+        
+        time.sleep(5)
+
+        evento_3 = {
+            "id_pacote": 1420,
+            "origem": "Porto Alegre",
+            "destino": "Curitiba",
+            "status_rastreamento": "ENTREGUE",
+            "data_atualizacao": "2025-10-12T17:40:00Z"
+        }
+        enviar_evento(kafka_producer, evento_3)
+
+        kafka_producer.flush()
+        kafka_producer.close()
+        logger.info("Produtor finalizado e todas as mensagens enviadas.")

--- a/desafio-2/requirements.txt
+++ b/desafio-2/requirements.txt
@@ -4,3 +4,4 @@ python-dotenv==1.1.1
 SQLAlchemy==2.0.43
 streamlit==1.50.0
 plotly==6.3.1
+kafka-python==2.2.15


### PR DESCRIPTION
## Processo de Pensamento

A implementação foi focada em criar um produtor que não apenas enviasse mensagens, mas que o fizesse de forma robusta e seguindo as boas práticas do ecossistema Kafka.
1. **Conexão e Serialização**: Foi utilizada a biblioteca `kafka-python` para a comunicação com o broker. A instância do `KafkaProducer` foi configurada com um `value_serializer` que converte os dicionários Python em JSON (usando `json.dumps`) e, em seguida, em bytes (`utf-8`), que é o formato que o Kafka transporta.
2. **Garantia de Entrega**: Para simular um ambiente de produção onde a perda de dados é inaceitável, o produtor foi configurado com `acks='all'`. Isso garante que o produtor só considere uma mensagem como "enviada" após o líder da partição e todas as suas réplicas confirmarem o recebimento, oferecendo o mais alto nível de durabilidade. Adicionalmente, `retries=5` foi configurado para lidar com falhas transitórias de rede.
3. **Modularização**: A lógica foi separada em funções distintas: `inicializar_producer()` para encapsular a criação da conexão e `enviar_evento()` para a lógica de envio de uma única mensagem. Isso torna o código mais limpo, reutilizável e fácil de testar.
4. **Script de Teste**: O bloco `if __name__ == "__main__":` foi utilizado para criar um pequeno simulador que envia uma sequência de eventos de exemplo, permitindo testar e validar o funcionamento do produtor de forma isolada.